### PR TITLE
Add deprecation notice; bsdtar is no longer needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Deprecated
+
+This repository is deprecated.
+
+BSD Tar is no longer needed for Windows stemcell creation as of (at least) Windows 2019.
+
+See: https://github.com/cloudfoundry/bosh-windows-stemcell-builder for more information about Windows Stemcells.


### PR DESCRIPTION
As of (at least) Windows 2019 `tar` is present on the base OS.

See: https://github.com/cloudfoundry/bosh-windows-stemcell-builder/commit/614bdc068f5f56357704c53ff81ef1a6a8b4486e